### PR TITLE
Improve shift calendar view

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index_page') }}">Vacation App</a>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('index_page') }}">Employees</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('vacations_page') }}">Vacations</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('shifts_page') }}">Shifts</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('calendar_page') }}">Calendar</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+{% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,128 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Vacation Calendar <span id="calendar-year"></span></h1>
+<div class="row mb-3">
+  <div class="col-md-2">
+    <select id="month-select" class="form-select">
+      <option value="7">Jul</option>
+      <option value="8">Avgust</option>
+      <option value="9">Septembar</option>
+    </select>
+  </div>
+  <div class="col-md-3">
+    <select id="position-filter" class="form-select">
+      <option value="">Sve pozicije</option>
+    </select>
+  </div>
+</div>
+<div class="table-responsive">
+  <table class="table table-bordered" id="calendar-table"></table>
+</div>
+<div class="mt-3">
+  <strong>Legend:</strong>
+  <span class="ms-2 position-tuber px-2">Tuber operator</span>
+  <span class="ms-2 position-pomocnik px-2">Assistant</span>
+  <span class="ms-2 position-botomer px-2">Botomer operator</span>
+  <span class="ms-2 position-pregledac px-2">Inspector</span>
+  <span class="ms-2 position-printer px-2">Printer</span>
+</div>
+<style>
+.position-tuber { background-color: #fff3cd; }
+.position-pomocnik { background-color: #ffe5b4; }
+.position-botomer { background-color: #d4edda; }
+.position-pregledac { background-color: #cce5ff; }
+.position-printer { background-color: #e2d6f9; }
+</style>
+<script>
+const weekdays = ['N','P','U','S','\u010c','P','S'];
+const year = new Date().getFullYear();
+document.getElementById('calendar-year').textContent = year;
+let allEmployees = [];
+let allVacations = [];
+
+function positionClass(pos){
+  const p = pos.toLowerCase();
+  if(p.includes('tuber')) return 'position-tuber';
+  if(p.includes('pomo')) return 'position-pomocnik';
+  if(p.includes('botomer')) return 'position-botomer';
+  if(p.includes('pregled')) return 'position-pregledac';
+  if(p.includes('printer')) return 'position-printer';
+  return '';
+}
+
+async function loadData() {
+  const [empRes, vacRes] = await Promise.all([
+    fetch('/employees'),
+    fetch('/vacations')
+  ]);
+  allEmployees = await empRes.json();
+  allVacations = await vacRes.json();
+  populatePositionFilter();
+}
+
+function populatePositionFilter(){
+  const select = document.getElementById('position-filter');
+  const positions = [...new Set(allEmployees.map(e => e.position))].sort();
+  select.innerHTML = '<option value="">Sve pozicije</option>' +
+    positions.map(p=>`<option value="${p}">${p}</option>`).join('');
+}
+
+function buildCalendar(month, year){
+  let employees = allEmployees;
+  const filter = document.getElementById('position-filter').value;
+  if(filter){
+    employees = employees.filter(e => e.position === filter);
+  }
+  const vacations = allVacations;
+  const days = new Date(year, month, 0).getDate();
+  const table = document.getElementById('calendar-table');
+  table.innerHTML = '';
+  const thead = document.createElement('thead');
+  let row = document.createElement('tr');
+  row.innerHTML = '<th>Radnik</th>' + Array.from({length:days},(_,i)=>`<th>${i+1}</th>`).join('');
+  thead.appendChild(row);
+  row = document.createElement('tr');
+  row.innerHTML = '<th>Dan</th>' + Array.from({length:days},(_,i)=>{
+      const d = new Date(year, month-1, i+1);
+      return `<th>${weekdays[d.getDay()]}</th>`;
+  }).join('');
+  thead.appendChild(row);
+  table.appendChild(thead);
+  const tbody = document.createElement('tbody');
+  employees.sort((a,b)=>a.position.localeCompare(b.position));
+  employees.forEach(emp=>{
+    const tr = document.createElement('tr');
+    tr.className = positionClass(emp.position);
+    let cells = `<td>${emp.first_name} ${emp.last_name}</td>`;
+    for(let d=1; d<=days; d++){
+      const ds = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+      const vac = vacations.find(v=>v.employee_id===emp.id && ds>=v.start_date && ds<=v.end_date);
+      if(vac){
+        cells += '<td class="bg-danger text-white">ODMOR</td>';
+      } else {
+        cells += '<td></td>';
+      }
+    }
+    tr.innerHTML = cells;
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+}
+
+document.getElementById('month-select').addEventListener('change', () => {
+  const month = parseInt(document.getElementById('month-select').value);
+  buildCalendar(month, year);
+});
+
+document.getElementById('position-filter').addEventListener('change', () => {
+  const month = parseInt(document.getElementById('month-select').value);
+  buildCalendar(month, year);
+});
+
+document.addEventListener('DOMContentLoaded', async ()=>{
+  await loadData();
+  const month = parseInt(document.getElementById('month-select').value);
+  buildCalendar(month, year);
+});
+</script>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Employees</h1>
+<div class="mb-3">
+    <form id="employee-form" class="row g-3">
+        <div class="col-md-4">
+            <input type="text" class="form-control" id="first_name" placeholder="First Name" required>
+        </div>
+        <div class="col-md-4">
+            <input type="text" class="form-control" id="last_name" placeholder="Last Name" required>
+        </div>
+        <div class="col-md-4">
+            <input type="text" class="form-control" id="position" placeholder="Position" required>
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary">Add Employee</button>
+        </div>
+    </form>
+</div>
+<table class="table" id="employees-table">
+    <thead><tr><th>First Name</th><th>Last Name</th><th>Position</th></tr></thead>
+    <tbody></tbody>
+</table>
+<script>
+async function loadEmployees() {
+    const res = await fetch('/employees');
+    const data = await res.json();
+    const tbody = document.querySelector('#employees-table tbody');
+    tbody.innerHTML = '';
+    data.forEach(emp => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${emp.first_name}</td><td>${emp.last_name}</td><td>${emp.position}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+document.getElementById('employee-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const payload = {
+        first_name: document.getElementById('first_name').value,
+        last_name: document.getElementById('last_name').value,
+        position: document.getElementById('position').value
+    };
+    const res = await fetch('/employees/add', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+    if (res.ok) {
+        e.target.reset();
+        loadEmployees();
+    } else {
+        alert('Failed to add employee');
+    }
+});
+
+loadEmployees();
+</script>
+{% endblock %}

--- a/templates/shifts.html
+++ b/templates/shifts.html
@@ -1,0 +1,179 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Shifts</h1>
+<div class="mb-3">
+    <form id="shift-form" class="row g-3">
+        <div class="col-md-3">
+            <input type="date" id="shift_start" class="form-control" required>
+        </div>
+        <div class="col-md-3">
+            <input type="date" id="shift_end" class="form-control" required>
+        </div>
+        <div class="col-md-3">
+            <select id="template_name" class="form-select" required>
+                <option value="3-smena">3-smena</option>
+                <option value="4-smena">4-smena</option>
+            </select>
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary">Generate Shifts</button>
+        </div>
+    </form>
+</div>
+<div id="calendar-container" class="table-responsive mb-4">
+    <table class="table table-bordered" id="shift-calendar"></table>
+</div>
+<div id="team-assignments"></div>
+<style>
+    .weekend { background-color: #cce5ff; }
+</style>
+<script>
+const weekdays = ['N','P','U','S','\u010c','P','S'];
+
+function buildCalendar(start, end, shiftCount){
+    const table = document.getElementById('shift-calendar');
+    table.innerHTML = '';
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    const days = [];
+    for(let d = new Date(startDate); d <= endDate; d.setDate(d.getDate()+1)){
+        days.push(new Date(d));
+    }
+
+    const header1 = document.createElement('tr');
+    header1.innerHTML = '<th></th>' + days.map(d=>`<th>${d.getDate()}</th>`).join('');
+    table.appendChild(header1);
+
+    const header2 = document.createElement('tr');
+    header2.innerHTML = '<th></th>' + days.map(d=>`<th>${weekdays[d.getDay()]}</th>`).join('');
+    table.appendChild(header2);
+
+    const groups = shiftCount === 4 ? ['A','B','C','D'] : ['A','B','C'];
+
+    if(shiftCount === 3){
+        const pattern = ['I','II','III'];
+        groups.forEach((g, gi)=>{
+            const row = document.createElement('tr');
+            row.innerHTML = `<th>${g}</th>`;
+            days.forEach((d)=>{
+                const cell = document.createElement('td');
+                if(d.getDay() === 0 || d.getDay() === 6){
+                    cell.className = 'weekend';
+                } else {
+                    const weekIndex = Math.floor((d - startDate) / (7*24*60*60*1000));
+                    cell.textContent = pattern[(weekIndex + gi) % pattern.length];
+                }
+                row.appendChild(cell);
+            });
+            table.appendChild(row);
+        });
+    } else {
+        const cycle = [
+            {shift:'I', days:4, break:1},
+            {shift:'II', days:4, break:1},
+            {shift:'III', days:4, break:2},
+            {shift:'IV', days:4, break:0},
+        ];
+        const totalDays = days.length;
+        groups.forEach((g, gi)=>{
+            const row = document.createElement('tr');
+            row.innerHTML = `<th>${g}</th>`;
+            let schedule = [];
+            let idx = gi % cycle.length;
+            while(schedule.length < totalDays){
+                for(let i=0;i<cycle[idx].days && schedule.length<totalDays;i++){
+                    schedule.push(cycle[idx].shift);
+                }
+                for(let b=0;b<cycle[idx].break && schedule.length<totalDays;b++){
+                    schedule.push('');
+                }
+                idx = (idx + 1) % cycle.length;
+            }
+            schedule.forEach(sh => {
+                const cell = document.createElement('td');
+                cell.textContent = sh;
+                row.appendChild(cell);
+            });
+            table.appendChild(row);
+        });
+    }
+}
+
+function assignTeams(start, end, shiftCount, employees, vacations){
+    const groups = shiftCount === 4 ? ['A','B','C','D'] : ['A','B','C'];
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    function available(emp){
+        return !vacations.some(v => v.employee_id === emp.id && !(endDate < new Date(v.start_date) || startDate > new Date(v.end_date)));
+    }
+    const pool = employees.filter(available);
+    const leaders = pool.filter(e => e.team_leader);
+    const byPos = {
+        tuber: pool.filter(e => e.position.toLowerCase().includes('tuber') && !e.team_leader),
+        pomocnik: pool.filter(e => e.position.toLowerCase().includes('pomo') && !e.team_leader),
+        botomer: pool.filter(e => e.position.toLowerCase().includes('botomer') && !e.team_leader),
+        pregledac: pool.filter(e => e.position.toLowerCase().includes('pregled') && !e.team_leader),
+    };
+
+    const teams = {};
+    groups.forEach(g => teams[g] = {leader:null, tuber:[], pomocnik:[], botomer:[], pregledac:[]});
+
+    groups.forEach(g => { teams[g].leader = leaders.shift() || null; });
+    ['tuber','pomocnik','botomer','pregledac'].forEach(pos => {
+        groups.forEach(g => {
+            for(let i=0;i<2;i++){
+                if(byPos[pos].length) teams[g][pos].push(byPos[pos].shift());
+            }
+        });
+    });
+    return teams;
+}
+
+function renderTeams(teams){
+    const container = document.getElementById('team-assignments');
+    container.innerHTML = '';
+    Object.entries(teams).forEach(([shift,info])=>{
+        const card = document.createElement('div');
+        card.className = 'mb-3 p-3 border';
+        let valid = info.leader && info.tuber.length===2 && info.pomocnik.length===2 && info.botomer.length===2 && info.pregledac.length===2;
+        if(!valid){
+            card.innerHTML = `<h5>Smena ${shift}</h5><div class="text-danger">Nedovoljno radnika za smenu ${shift}</div>`;
+        }else{
+            const list = `
+                <ul>
+                    <li>Tim lider: ${info.leader.first_name} ${info.leader.last_name}</li>
+                    <li>Operater tuber: ${info.tuber.map(e=>e.first_name+' '+e.last_name).join(', ')}</li>
+                    <li>Pomocnik: ${info.pomocnik.map(e=>e.first_name+' '+e.last_name).join(', ')}</li>
+                    <li>Botomer: ${info.botomer.map(e=>e.first_name+' '+e.last_name).join(', ')}</li>
+                    <li>Pregledac: ${info.pregledac.map(e=>e.first_name+' '+e.last_name).join(', ')}</li>
+                </ul>`;
+            card.innerHTML = `<h5>Smena ${shift}</h5>${list}`;
+        }
+        container.appendChild(card);
+    });
+}
+
+document.getElementById('shift-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const start = document.getElementById('shift_start').value;
+    const end = document.getElementById('shift_end').value;
+    const template = document.getElementById('template_name').value;
+
+    await fetch('/shifts/generate', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({start_date:start, end_date:end, template_name:template})
+    });
+
+    const [employees, vacations] = await Promise.all([
+        fetch('/employees').then(r=>r.json()),
+        fetch('/vacations').then(r=>r.json())
+    ]);
+
+    const shiftCount = template === '4-smena' ? 4 : 3;
+    buildCalendar(start, end, shiftCount);
+    const teams = assignTeams(start, end, shiftCount, employees, vacations);
+    renderTeams(teams);
+});
+</script>
+{% endblock %}

--- a/templates/vacations.html
+++ b/templates/vacations.html
@@ -1,0 +1,142 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Vacations</h1>
+<div class="mb-3">
+    <form id="vacation-form" class="row g-3">
+        <div class="col-md-4">
+            <select id="employee_select" class="form-select" required></select>
+        </div>
+        <div class="col-md-3">
+            <input type="date" class="form-control" id="vac_start" required>
+        </div>
+        <div class="col-md-3">
+            <input type="date" class="form-control" id="vac_end" required>
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary">Add Vacation</button>
+        </div>
+    </form>
+</div>
+<table class="table" id="vacations-table">
+    <thead><tr><th>Employee</th><th>Start</th><th>End</th><th>Actions</th></tr></thead>
+    <tbody></tbody>
+</table>
+<div class="modal fade" id="editModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="edit-form">
+        <div class="modal-header">
+          <h5 class="modal-title">Edit Vacation</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+            <input type="hidden" id="edit-id">
+            <div class="mb-3">
+                <label class="form-label">Start Date</label>
+                <input type="date" class="form-control" id="edit-start" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">End Date</label>
+                <input type="date" class="form-control" id="edit-end" required>
+            </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          <button type="submit" class="btn btn-primary">Save changes</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<script>
+async function loadEmployees() {
+    const res = await fetch('/employees');
+    const data = await res.json();
+    const sel = document.getElementById('employee_select');
+    sel.innerHTML = '';
+    data.forEach(emp => {
+        const option = document.createElement('option');
+        option.value = emp.id;
+        option.textContent = emp.first_name + ' ' + emp.last_name + ' (' + emp.position + ')';
+        sel.appendChild(option);
+    });
+}
+async function loadVacations() {
+    const res = await fetch('/vacations');
+    const data = await res.json();
+    const employees = await (await fetch('/employees')).json();
+    const tbody = document.querySelector('#vacations-table tbody');
+    tbody.innerHTML = '';
+    data.forEach(vac => {
+        const emp = employees.find(e => e.id === vac.employee_id) || {};
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${emp.first_name || ''} ${emp.last_name || ''}</td>` +
+            `<td>${vac.start_date}</td><td>${vac.end_date}</td>` +
+            `<td><button class="btn btn-sm btn-secondary edit-btn" data-id="${vac.id}" data-start="${vac.start_date}" data-end="${vac.end_date}">Edit</button></td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+document.getElementById('vacation-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const payload = {
+        employee_id: document.getElementById('employee_select').value,
+        start_date: document.getElementById('vac_start').value,
+        end_date: document.getElementById('vac_end').value
+    };
+    const checkRes = await fetch('/vacations/check', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+    const checkData = await checkRes.json();
+    if (checkData.conflicts && checkData.conflicts.length) {
+        alert('Vacation conflicts with another employee from the same position.');
+        return;
+    }
+    const addRes = await fetch('/vacations/add', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+    if (addRes.ok) {
+        e.target.reset();
+        loadVacations();
+    } else {
+        alert('Failed to add vacation');
+    }
+});
+
+document.querySelector('#vacations-table tbody').addEventListener('click', e => {
+    if(e.target.classList.contains('edit-btn')){
+        document.getElementById('edit-id').value = e.target.dataset.id;
+        document.getElementById('edit-start').value = e.target.dataset.start;
+        document.getElementById('edit-end').value = e.target.dataset.end;
+        new bootstrap.Modal(document.getElementById('editModal')).show();
+    }
+});
+
+document.getElementById('edit-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const payload = {
+        id: document.getElementById('edit-id').value,
+        start_date: document.getElementById('edit-start').value,
+        end_date: document.getElementById('edit-end').value
+    };
+    const res = await fetch('/vacations/update', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+    if(res.ok){
+        bootstrap.Modal.getInstance(document.getElementById('editModal')).hide();
+        loadVacations();
+    }else{
+        alert('Failed to update vacation');
+    }
+});
+
+loadEmployees();
+loadVacations();
+</script>
+{% endblock %}

--- a/vacation_app.py
+++ b/vacation_app.py
@@ -1,0 +1,269 @@
+import os
+import json
+import uuid
+from datetime import datetime, timedelta
+from flask import Flask, request, jsonify, render_template
+from flask_cors import CORS
+
+app = Flask(__name__)
+CORS(app)
+
+# Directory for storing JSON data files
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(BASE_DIR, 'data')
+
+EMPLOYEES_FILE = os.path.join(DATA_DIR, 'employees.json')
+VACATIONS_FILE = os.path.join(DATA_DIR, 'vacations.json')
+TEMPLATES_FILE = os.path.join(DATA_DIR, 'shift_templates.json')
+SHIFTS_FILE = os.path.join(DATA_DIR, 'shifts.json')
+
+
+def ensure_file(path, default):
+    """Create file with default content if it does not exist."""
+    if not os.path.exists(DATA_DIR):
+        os.makedirs(DATA_DIR)
+    if not os.path.isfile(path):
+        with open(path, 'w') as f:
+            json.dump(default, f, indent=2)
+
+
+def load_data(path, default):
+    ensure_file(path, default)
+    with open(path, 'r') as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            return default
+
+
+def save_data(path, data):
+    ensure_file(path, data)
+    with open(path, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+# Default shift templates
+DEFAULT_TEMPLATES = [
+    {
+        "template_name": "3-smena",
+        "days": ["I", "II", "III", "slobodan"],
+    },
+    {
+        "template_name": "4-smena",
+        "days": ["I", "II", "III", "IV", "slobodan"],
+    },
+]
+
+
+@app.route('/employees', methods=['GET'])
+def get_employees():
+    employees = load_data(EMPLOYEES_FILE, [])
+    return jsonify(employees)
+
+
+@app.route('/employees/add', methods=['POST'])
+def add_employee():
+    data = request.get_json(force=True)
+    first_name = data.get('first_name')
+    last_name = data.get('last_name')
+    position = data.get('position')
+    if not all([first_name, last_name, position]):
+        return jsonify({'error': 'Missing employee data'}), 400
+
+    employee = {
+        'id': str(uuid.uuid4()),
+        'first_name': first_name,
+        'last_name': last_name,
+        'position': position,
+    }
+
+    employees = load_data(EMPLOYEES_FILE, [])
+    employees.append(employee)
+    save_data(EMPLOYEES_FILE, employees)
+    return jsonify(employee), 201
+
+
+@app.route('/vacations', methods=['GET'])
+def get_vacations():
+    vacations = load_data(VACATIONS_FILE, [])
+    return jsonify(vacations)
+
+
+@app.route('/vacations/add', methods=['POST'])
+def add_vacation():
+    data = request.get_json(force=True)
+    employee_id = data.get('employee_id')
+    start_date = data.get('start_date')
+    end_date = data.get('end_date')
+
+    if not all([employee_id, start_date, end_date]):
+        return jsonify({'error': 'Missing vacation data'}), 400
+
+    try:
+        sd = datetime.strptime(start_date, '%Y-%m-%d')
+        ed = datetime.strptime(end_date, '%Y-%m-%d')
+    except ValueError:
+        return jsonify({'error': 'Invalid date format'}), 400
+    if sd > ed:
+        return jsonify({'error': 'Start date must be before end date'}), 400
+
+    vacation = {
+        'id': str(uuid.uuid4()),
+        'employee_id': employee_id,
+        'start_date': start_date,
+        'end_date': end_date,
+    }
+    vacations = load_data(VACATIONS_FILE, [])
+    vacations.append(vacation)
+    save_data(VACATIONS_FILE, vacations)
+    return jsonify(vacation), 201
+
+
+@app.route('/vacations/update', methods=['POST'])
+def update_vacation():
+    data = request.get_json(force=True)
+    vac_id = data.get('id')
+    start_date = data.get('start_date')
+    end_date = data.get('end_date')
+
+    if not all([vac_id, start_date, end_date]):
+        return jsonify({'error': 'Missing data'}), 400
+
+    vacations = load_data(VACATIONS_FILE, [])
+    for vac in vacations:
+        if vac.get('id') == vac_id:
+            vac['start_date'] = start_date
+            vac['end_date'] = end_date
+            save_data(VACATIONS_FILE, vacations)
+            return jsonify(vac)
+
+    return jsonify({'error': 'Vacation not found'}), 404
+
+
+def _get_employee_by_id(emp_id, employees):
+    for emp in employees:
+        if emp['id'] == emp_id:
+            return emp
+    return None
+
+
+@app.route('/vacations/check', methods=['POST'])
+def check_vacations():
+    data = request.get_json(force=True)
+    employee_id = data.get('employee_id')
+    start_date = data.get('start_date')
+    end_date = data.get('end_date')
+
+    if not all([employee_id, start_date, end_date]):
+        return jsonify({'error': 'Missing data'}), 400
+
+    try:
+        sd = datetime.strptime(start_date, '%Y-%m-%d')
+        ed = datetime.strptime(end_date, '%Y-%m-%d')
+    except ValueError:
+        return jsonify({'error': 'Invalid date format'}), 400
+
+    employees = load_data(EMPLOYEES_FILE, [])
+    vacations = load_data(VACATIONS_FILE, [])
+
+    employee = _get_employee_by_id(employee_id, employees)
+    if not employee:
+        return jsonify({'error': 'Employee not found'}), 404
+
+    position = employee['position']
+    conflicts = []
+    for vac in vacations:
+        if vac['employee_id'] == employee_id:
+            continue
+        other_emp = _get_employee_by_id(vac['employee_id'], employees)
+        if not other_emp or other_emp['position'] != position:
+            continue
+        v_start = datetime.strptime(vac['start_date'], '%Y-%m-%d')
+        v_end = datetime.strptime(vac['end_date'], '%Y-%m-%d')
+        if not (ed < v_start or sd > v_end):
+            conflicts.append(vac)
+
+    return jsonify({'conflicts': conflicts})
+
+
+@app.route('/shifts/generate', methods=['POST'])
+def generate_shifts():
+    data = request.get_json(force=True)
+    start_date = data.get('start_date')
+    end_date = data.get('end_date')
+    template_name = data.get('template_name')
+
+    if not all([start_date, end_date, template_name]):
+        return jsonify({'error': 'Missing data'}), 400
+
+    try:
+        sd = datetime.strptime(start_date, '%Y-%m-%d')
+        ed = datetime.strptime(end_date, '%Y-%m-%d')
+    except ValueError:
+        return jsonify({'error': 'Invalid date format'}), 400
+    if sd > ed:
+        return jsonify({'error': 'Start date must be before end date'}), 400
+
+    templates = load_data(TEMPLATES_FILE, DEFAULT_TEMPLATES)
+    template = next((t for t in templates if t['template_name'] == template_name), None)
+    if not template:
+        return jsonify({'error': 'Template not found'}), 404
+
+    employees = load_data(EMPLOYEES_FILE, [])
+    vacations = load_data(VACATIONS_FILE, [])
+
+    shifts = []
+    for emp in employees:
+        pattern_index = 0
+        current = sd
+        while current <= ed:
+            on_vac = False
+            for vac in vacations:
+                if vac['employee_id'] == emp['id']:
+                    v_start = datetime.strptime(vac['start_date'], '%Y-%m-%d')
+                    v_end = datetime.strptime(vac['end_date'], '%Y-%m-%d')
+                    if v_start <= current <= v_end:
+                        on_vac = True
+                        break
+            if not on_vac:
+                shift_name = template['days'][pattern_index % len(template['days'])]
+                shifts.append({
+                    'date': current.strftime('%Y-%m-%d'),
+                    'shift': shift_name,
+                    'employee_id': emp['id'],
+                })
+                pattern_index += 1
+            current += timedelta(days=1)
+
+    save_data(SHIFTS_FILE, shifts)
+    return jsonify({'message': 'Shift schedule generated', 'shifts_created': len(shifts)})
+
+
+@app.route('/shifts', methods=['GET'])
+def get_shifts():
+    shifts = load_data(SHIFTS_FILE, [])
+    return jsonify(shifts)
+
+
+@app.route('/')
+def index_page():
+    return render_template('index.html', title='Employees')
+
+
+@app.route('/vacations_page')
+def vacations_page():
+    return render_template('vacations.html', title='Vacations')
+
+
+@app.route('/shifts_page')
+def shifts_page():
+    return render_template('shifts.html', title='Shifts')
+
+
+@app.route('/calendar_page')
+def calendar_page():
+    return render_template('calendar.html', title='Calendar')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- render a monthly shift calendar with weekend highlights
- auto-assign teams for each shift and show members below the calendar
- rotate 3-shift schedules weekly and handle 4-shift breaks
- add ability to edit existing vacation entries

## Testing
- `python3 -m py_compile vacation_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684bbd264cf4832398d9fc2afa54dc86